### PR TITLE
Add note about SonarQube's prerequisities

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Subscribe to project updates by watching the [bitnami/sonarqube GitHub repo](htt
 
 To run this application you need [Docker Engine](https://www.docker.com/products/docker-engine) >= `1.10.0`. [Docker Compose](https://www.docker.com/products/docker-compose) is recommended with a version `1.6.0` or later.
 
+Please also make sure your host machine meets the [requirements of SonarQube](https://docs.sonarqube.org/latest/requirements/requirements/) itself, taking extra care about [the platform notes section](https://docs.sonarqube.org/latest/requirements/requirements/#header-6).
+
 # How to use this image
 
 SonarQube requires access to a PostgreSQL database to store information. We'll use our very own [PostgreSQL image](https://www.github.com/bitnami/bitnami-docker-postgresql) for the database requirements.


### PR DESCRIPTION
I would like to add this extra note to the readme file. I know it's a first step to check the requirements of any software you install, but this is something that gets easily overlooked, especially in case of Docker, when people tend to (falsely) assume that every configuration that's needed will be in the image itself.

There's a bunch of already closed issues that stem from ignoring these prerequisites (#15 #14 #12 #4), so hopefully this minor change will decrease the number of similar issues in the future.