### PR TITLE
The SonarQube user is created as 1001:1001

### DIFF
--- a/9/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
+++ b/9/debian-10/prebuildfs/opt/bitnami/scripts/libos.sh
@@ -39,18 +39,24 @@ group_exists() {
 # Arguments:
 #   $1 - group
 # Flags:
+#   --gid - When the group doesn't exist forces an ID for creation
 #   -s|--system - Whether to create new user as system user (uid <= 999)
 # Returns:
 #   None
 #########################
 ensure_group_exists() {
     local group="${1:?group is missing}"
+    local gid=""
     local is_system_user=false
 
     # Validate arguments
     shift 1
     while [ "$#" -gt 0 ]; do
         case "$1" in
+            --gid)
+                shift
+                gid="${1:?missing gid}"
+                ;;
             -s|--system)
                 is_system_user=true
                 ;;
@@ -64,6 +70,13 @@ ensure_group_exists() {
 
     if ! group_exists "$group"; then
         local -a args=("$group")
+        if [ -n "$gid" ]; then
+            if group_exists "$gid" ; then
+                echo "The GID $gid is already in use." >&2
+                return 1
+            fi
+            args+=("--gid" "$gid")
+        fi
         $is_system_user && args+=("--system")
         groupadd "${args[@]}" >/dev/null 2>&1
     fi
@@ -74,7 +87,9 @@ ensure_group_exists() {
 # Arguments:
 #   $1 - user
 # Flags:
+#   --uid - when the user doesn't exist forces an ID for creation
 #   -g|--group - the group the new user should belong to
+#   --append-groups - append the user to the supplemental GROUPS
 #   -h|--home - the home directory for the new user
 #   -s|--system - whether to create new user as system user (uid <= 999)
 # Returns:
@@ -82,7 +97,9 @@ ensure_group_exists() {
 #########################
 ensure_user_exists() {
     local user="${1:?user is missing}"
+    local uid=""
     local group=""
+    local append_groups=""
     local home=""
     local is_system_user=false
 
@@ -90,9 +107,17 @@ ensure_user_exists() {
     shift 1
     while [ "$#" -gt 0 ]; do
         case "$1" in
+            --uid)
+                shift
+                uid="${1:?missing uid}"
+                ;;
             -g|--group)
                 shift
                 group="${1:?missing group}"
+                ;;
+            --append-groups)
+                shift
+                append_groups="${1:?missing append_groups}"
                 ;;
             -h|--home)
                 shift
@@ -111,6 +136,13 @@ ensure_user_exists() {
 
     if ! user_exists "$user"; then
         local -a user_args=("-N" "$user")
+        if [ -n "$uid" ]; then
+            if user_exists "$uid" ; then
+                echo "The UID $uid is already in use." >&2
+                return 1
+            fi
+            user_args+=("--uid" "$uid")
+        fi
         $is_system_user && user_args+=("--system")
         useradd "${user_args[@]}" >/dev/null 2>&1
     fi
@@ -120,6 +152,12 @@ ensure_user_exists() {
         $is_system_user && group_args+=("--system")
         ensure_group_exists "${group_args[@]}"
         usermod -g "$group" "$user" >/dev/null 2>&1
+    fi
+
+    if [[ -n "$append_groups" ]]; then
+        local IFS=','
+        for g in $append_groups ; do ensure_group_exists "$g" ; done
+        usermod -aG "$append_groups" "$user" >/dev/null 2>&1
     fi
 
     if [[ -n "$home" ]]; then

--- a/9/debian-10/rootfs/opt/bitnami/scripts/sonarqube-env.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/sonarqube-env.sh
@@ -91,7 +91,9 @@ export SONARQUBE_DATA_TO_PERSIST="${SONARQUBE_DATA_TO_PERSIST:-${SONARQUBE_DATA_
 
 # System users (when running with a privileged user)
 export SONARQUBE_DAEMON_USER="sonarqube"
+export SONARQUBE_DAEMON_USER_ID="1001"
 export SONARQUBE_DAEMON_GROUP="sonarqube"
+export SONARQUBE_DAEMON_GROUP_ID="1001"
 
 # SonarQube configuration
 export SONARQUBE_PORT_NUMBER="${SONARQUBE_PORT_NUMBER:-9000}"

--- a/9/debian-10/rootfs/opt/bitnami/scripts/sonarqube/postunpack.sh
+++ b/9/debian-10/rootfs/opt/bitnami/scripts/sonarqube/postunpack.sh
@@ -30,7 +30,8 @@ replace_in_file "${SONARQUBE_CONF_DIR}/wrapper.conf" "^[#\s]*wrapper.logfile.rol
 # Ensure the SonarQube base directory exists and has proper permissions
 # Based on https://github.com/SonarSource/docker-sonarqube/blob/master/9/community/Dockerfile#L129
 info "Configuring file permissions for SonarQube"
-ensure_user_exists "$SONARQUBE_DAEMON_USER" --group "$SONARQUBE_DAEMON_GROUP" --system
+ensure_group_exists "$SONARQUBE_DAEMON_GROUP" --gid "$SONARQUBE_DAEMON_GROUP_ID"
+ensure_user_exists "$SONARQUBE_DAEMON_USER" --system --uid "$SONARQUBE_DAEMON_USER_ID" --group "$SONARQUBE_DAEMON_GROUP" --append-groups "root"
 for dir in "$SONARQUBE_DATA_DIR" "$SONARQUBE_EXTENSIONS_DIR" "$SONARQUBE_LOGS_DIR" "$SONARQUBE_TMP_DIR" "${SONARQUBE_BASE_DIR}/pids" "$SONARQUBE_VOLUME_DIR"; do
     ensure_dir_exists "$dir"
     # Use daemon:root ownership for compatibility when running as a non-root user


### PR DESCRIPTION
**Description of the change**

This PR contains a change to create sonarqube user as 1001:1001. Also, this change preserves the permissions on root group for backward compatibility.

**Benefits**

This change allows to use the same user for run the container and the daemon process.

**Possible drawbacks**

**Applicable issues**

#41 

**Additional information**

- I kept the way to create the groups and users by `libos.sh` but in summary the change would be:
```
# Create the group
addgroup --gid 1001 sonarqube
# Create the user
adduser --system --gid 1001 --uid 1001 sonarqube
# Append root group to user
usermod -aG root sonarqube
```


- The non-root user mapping:

```sh
sonarqube@d1dfc1283a1d:/$ id
uid=1001(sonarqube) gid=1001(sonarqube) groups=1001(sonarqube),0(root)
```
